### PR TITLE
refactor: use vim.g config and lazy loading

### DIFF
--- a/plugin/http-codes.lua
+++ b/plugin/http-codes.lua
@@ -1,0 +1,8 @@
+if vim.g.loaded_http_codes then
+  return
+end
+vim.g.loaded_http_codes = 1
+
+vim.api.nvim_create_user_command('HTTPCodes', function()
+  require('http-codes').pick()
+end, {})


### PR DESCRIPTION
## Summary
- Replace `setup()` with `vim.g.http_codes` configuration
- Add `plugin/http-codes.lua` with load guard for lazy loading

Config is now read lazily on first `:HTTPCodes` invocation. Picker auto-detection still works.