### PR TITLE
docs: modernize readme, move config to vimdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ luarocks install http-codes.nvim
 ## Dependencies
 
 One of:
+
 - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
 - [snacks.nvim](https://github.com/folke/snacks.nvim)
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # http-codes.nvim
 
-Quickly investigate HTTP status codes with the help of [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP), with telescope, fzf-lua, and snacks.nvim integrations.
+Quickly investigate HTTP status codes with [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP), with telescope, fzf-lua, and snacks.nvim integrations.
 
 ## Installation
 
-Install using your package manager of choice or via [luarocks](https://luarocks.org/modules/barrettruth/http-codes.nvim):
+Install with your package manager or via
+[luarocks](https://luarocks.org/modules/barrettruth/http-codes.nvim):
 
 ```
 luarocks install http-codes.nvim
@@ -13,33 +14,9 @@ luarocks install http-codes.nvim
 ## Dependencies
 
 One of:
-
 - [fzf-lua](https://github.com/ibhagwan/fzf-lua)
 - [snacks.nvim](https://github.com/folke/snacks.nvim)
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
-
-## Configuration
-
-Configure via `vim.g.http_codes` before the plugin loads:
-
-```lua
-vim.g.http_codes = {
-  use = 'fzf-lua', -- or 'snacks' or 'telescope', auto-detected by default
-  open_url = 'xdg-open %s', -- OS-specific by default
-}
-```
-
-| OS      | Default open_url |
-| ------- | ---------------- |
-| Windows | `start %s`       |
-| macOS   | `open %s`        |
-| Linux   | `xdg-open %s`    |
-
-## Usage
-
-```vim
-:HTTPCodes
-```
 
 ## Documentation
 

--- a/doc/http-codes.txt
+++ b/doc/http-codes.txt
@@ -1,39 +1,42 @@
-http-codes                                                      *http-codes.txt*
+*http-codes* *http-codes.txt*
 
 Author: Barrett Ruth <https://barrettruth.com>
-Homepage: <https://github.com/barrettruth/http-codes.nvim>
+Homepage: <https://github.com/barrett-ruth/http-codes.nvim>
 
 ===============================================================================
 INTRODUCTION                                                 *http-codes.nvim*
 
-http-codes.nvim lets you quickly investigate HTTP status codes with Mozilla,
-supporting fzf-lua, snacks.nvim, and telescope.nvim.
+http-codes.nvim lets you quickly investigate HTTP status codes using Mozilla
+documentation, with telescope, fzf-lua, and snacks.nvim integrations.
 
 ===============================================================================
-CONFIGURATION                                              *http-codes.config*
+USAGE                                                            *:HTTPCodes*
 
-Configure via `vim.g.http_codes` before the plugin loads:
+>vim
+    :HTTPCodes
+<
+
+===============================================================================
+CONFIGURATION                                             *vim.g.http_codes*
+
+Configure via `vim.g.http_codes`:
+
 >lua
     vim.g.http_codes = {
+        -- Picker: 'fzf-lua', 'snacks', or 'telescope' (auto-detected)
         use = 'fzf-lua',
+        -- Command to open URLs (OS-specific by default)
         open_url = 'xdg-open %s',
     }
 <
-Options: ~
 
-    {use}       `(string|nil)`: Picker to use: 'fzf-lua', 'snacks', or
-                              'telescope'. Auto-detected if not specified.
+Default `open_url` by operating system:
 
-    {open_url}  `(string|nil)`: Command to open URLs. Uses `%s` as placeholder.
-                              Defaults based on OS:
-                              - Linux: 'xdg-open %s'
-                              - macOS: 'open %s'
-                              - Windows: 'start %s'
-
-===============================================================================
-COMMANDS                                                 *http-codes.commands*
-
-:HTTPCodes            Browse HTTP codes using the configured picker.
+    OS          Default
+    --------    ---------------
+    Windows     start %s
+    macOS       open %s
+    Linux       xdg-open %s
 
 -------------------------------------------------------------------------------
-vim:tw=80:ft=help:
+vim:tw=80:ts=8:ft=help:


### PR DESCRIPTION
## Summary
- Simplified README.md to minimal structure with installation, dependencies, and documentation reference
- Moved full configuration documentation to vimdoc (doc/http-codes.txt)
- Added OS-specific open_url defaults table to vimdoc