### PR TITLE
feat: add <Plug> mappings

### DIFF
--- a/doc/http-codes.txt
+++ b/doc/http-codes.txt
@@ -17,6 +17,17 @@ USAGE                                                            *:HTTPCodes*
 <
 
 ===============================================================================
+MAPPINGS                                                *http-codes-mappings*
+
+                                                      *<Plug>(http-codes-pick)*
+<Plug>(http-codes-pick)     Open the HTTP status code picker.
+                            Equivalent to |:HTTPCodes|.
+
+Example configuration: >lua
+    vim.keymap.set('n', '<leader>hc', '<Plug>(http-codes-pick)')
+<
+
+===============================================================================
 CONFIGURATION                                             *vim.g.http_codes*
 
 Configure via `vim.g.http_codes`:

--- a/plugin/http-codes.lua
+++ b/plugin/http-codes.lua
@@ -7,4 +7,6 @@ vim.api.nvim_create_user_command('HTTPCodes', function()
   require('http-codes').pick()
 end, {})
 
-vim.keymap.set('n', '<Plug>(http-codes-pick)', function() require('http-codes').pick() end, { desc = 'Pick HTTP status code' })
+vim.keymap.set('n', '<Plug>(http-codes-pick)', function()
+  require('http-codes').pick()
+end, { desc = 'Pick HTTP status code' })

--- a/plugin/http-codes.lua
+++ b/plugin/http-codes.lua
@@ -6,3 +6,5 @@ vim.g.loaded_http_codes = 1
 vim.api.nvim_create_user_command('HTTPCodes', function()
   require('http-codes').pick()
 end, {})
+
+vim.keymap.set('n', '<Plug>(http-codes-pick)', function() require('http-codes').pick() end, { desc = 'Pick HTTP status code' })


### PR DESCRIPTION
## Problem

Users who want keybindings must call Lua functions directly or wrap
commands in closures. There is no stable public API for key binding.

## Solution

Define <Plug> mappings in the plugin file and document them in a new
MAPPINGS section in the vimdoc.