### PR TITLE
ci: format vimdoc help file

### DIFF
--- a/doc/http-codes.txt
+++ b/doc/http-codes.txt
@@ -3,23 +3,23 @@
 Author: Barrett Ruth <https://barrettruth.com>
 Homepage: <https://github.com/barrett-ruth/http-codes.nvim>
 
-===============================================================================
+==============================================================================
 INTRODUCTION                                                 *http-codes.nvim*
 
 http-codes.nvim lets you quickly investigate HTTP status codes using Mozilla
 documentation, with telescope, fzf-lua, and snacks.nvim integrations.
 
-===============================================================================
-USAGE                                                            *:HTTPCodes*
+==============================================================================
+USAGE                                                             *:HTTPCodes*
 
 >vim
     :HTTPCodes
 <
 
-===============================================================================
-MAPPINGS                                                *http-codes-mappings*
+==============================================================================
+MAPPINGS                                                 *http-codes-mappings*
 
-                                                      *<Plug>(http-codes-pick)*
+                                                     *<Plug>(http-codes-pick)*
 <Plug>(http-codes-pick)     Open the HTTP status code picker.
                             Equivalent to |:HTTPCodes|.
 
@@ -27,8 +27,8 @@ Example configuration: >lua
     vim.keymap.set('n', '<leader>hc', '<Plug>(http-codes-pick)')
 <
 
-===============================================================================
-CONFIGURATION                                             *vim.g.http_codes*
+==============================================================================
+CONFIGURATION                                               *vim.g.http_codes*
 
 Configure via `vim.g.http_codes`:
 
@@ -49,5 +49,5 @@ Default `open_url` by operating system:
     macOS       open %s
     Linux       xdg-open %s
 
--------------------------------------------------------------------------------
+------------------------------------------------------------------------------
 vim:tw=80:ts=8:ft=help:


### PR DESCRIPTION
## Problem

Help file had 79-column separators and unaligned heading tags.

## Solution

Format with `vimdoc-language-server`.