### PR TITLE
docs: rename help file to `http-codes.nvim.txt`

### DIFF
--- a/doc/http-codes.nvim.txt
+++ b/doc/http-codes.nvim.txt
@@ -1,7 +1,7 @@
-*http-codes* *http-codes.txt*
+*http-codes* *http-codes.nvim.txt*
 
-Author: Barrett Ruth <https://barrettruth.com>
-Homepage: <https://github.com/barrett-ruth/http-codes.nvim>
+Author: Barrett Ruth <https://barrettruth.com> Homepage:
+<https://github.com/barrett-ruth/http-codes.nvim>
 
 ==============================================================================
 INTRODUCTION                                                 *http-codes.nvim*


### PR DESCRIPTION
## Problem

Help file was named `http-codes.txt` with `*http-codes.txt*` first-line tag, inconsistent with the `*http-codes.nvim*` tag.

## Solution

Rename to `http-codes.nvim.txt` and update the first-line tag to `*http-codes.nvim.txt*`.